### PR TITLE
Exposes transition and value on InvalidStateTransition

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -11,6 +11,15 @@ public final class app/cash/kfsm/InvalidStateMachine : java/lang/Exception {
 
 public final class app/cash/kfsm/InvalidStateTransition : java/lang/Exception {
 	public fun <init> (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)V
+	public final fun component1 ()Lapp/cash/kfsm/Transition;
+	public final fun component2 ()Lapp/cash/kfsm/Value;
+	public final fun copy (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)Lapp/cash/kfsm/InvalidStateTransition;
+	public static synthetic fun copy$default (Lapp/cash/kfsm/InvalidStateTransition;Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;ILjava/lang/Object;)Lapp/cash/kfsm/InvalidStateTransition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTransition ()Lapp/cash/kfsm/Transition;
+	public final fun getValue ()Lapp/cash/kfsm/Value;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public class app/cash/kfsm/State {

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -11,12 +11,10 @@ public final class app/cash/kfsm/InvalidStateMachine : java/lang/Exception {
 
 public final class app/cash/kfsm/InvalidStateTransition : java/lang/Exception {
 	public fun <init> (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)V
-	public final fun component1 ()Lapp/cash/kfsm/Transition;
 	public final fun component2 ()Lapp/cash/kfsm/Value;
 	public final fun copy (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)Lapp/cash/kfsm/InvalidStateTransition;
 	public static synthetic fun copy$default (Lapp/cash/kfsm/InvalidStateTransition;Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;ILjava/lang/Object;)Lapp/cash/kfsm/InvalidStateTransition;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getTransition ()Lapp/cash/kfsm/Transition;
 	public final fun getValue ()Lapp/cash/kfsm/Value;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
@@ -1,6 +1,6 @@
 package app.cash.kfsm
 
-data class InvalidStateTransition(val transition: Transition<*, *>, val value: Value<*, *>) : Exception(
+data class InvalidStateTransition(private val transition: Transition<*, *>, val value: Value<*, *>) : Exception(
   "Value cannot transition ${
     transition.from.set.toList().sortedBy { it.toString() }.joinToString(", ", prefix = "{", postfix = "}")
   } to ${transition.to}, because it is currently ${value.state}. [value=$value]"

--- a/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/InvalidStateTransition.kt
@@ -1,7 +1,13 @@
 package app.cash.kfsm
 
-class InvalidStateTransition(transition: Transition<*, *>, value: Value<*, *>) : Exception(
+data class InvalidStateTransition(val transition: Transition<*, *>, val value: Value<*, *>) : Exception(
   "Value cannot transition ${
     transition.from.set.toList().sortedBy { it.toString() }.joinToString(", ", prefix = "{", postfix = "}")
   } to ${transition.to}, because it is currently ${value.state}. [value=$value]"
-)
+) {
+  /**
+   * Get the state of the underlying value.
+   * This reflects the state that could not be transitioned successfully.
+   */
+  inline fun <reified S: State<S>> getState(): S? = value.state as? S
+}

--- a/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
@@ -1,6 +1,7 @@
 package app.cash.kfsm
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 
 class InvalidStateTransitionTest : StringSpec({
@@ -12,5 +13,11 @@ class InvalidStateTransitionTest : StringSpec({
   "with many from-states has correct message" {
     InvalidStateTransition(LetterTransition(States(C, B), D), Letter(E)).message shouldBe
       "Value cannot transition {B, C} to D, because it is currently E. [value=Letter(state=E)]"
+  }
+
+  "exposes transition and state" {
+    val error = InvalidStateTransition(LetterTransition(A, B), Letter(E))
+
+    error.getState<Char>() shouldBe E
   }
 })


### PR DESCRIPTION
Allows consumers to access the state for which the value could not be
transitioned.

Useful for partitioning transition failures into categories, e.g.
known failures, and unknown or unexpected failures.
