### PR TITLE
Add function StateMachine.transitionToState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Breaking
+- Renamed `InvalidStateTransition` to `InvalidStateForTransition` to better reflect its purpose. This is a breaking change that requires updating any code that catches or references this exception type.
+
+### Added
+- Added `transitionToState` function to `StateMachine` that allows transitioning to a specific state if it's immediately reachable. This provides a simpler API for cases where the caller knows the target state and doesn't need to specify a particular transition.
+
 ## [0.8.3]
 
 * Fixed dependency configuration in order to fix a runtime failure with lib-guice.

--- a/lib-guice/api/lib-guice.api
+++ b/lib-guice/api/lib-guice.api
@@ -29,6 +29,7 @@ public final class app/cash/kfsm/guice/StateMachine {
 	public final fun execute-gIAlu-s (Lapp/cash/kfsm/Value;Lapp/cash/kfsm/Transition;)Ljava/lang/Object;
 	public final fun getAvailableTransitions (Lapp/cash/kfsm/State;)Ljava/util/Set;
 	public final fun getTransition (Lkotlin/reflect/KClass;)Lapp/cash/kfsm/Transition;
+	public final fun transitionToState-gIAlu-s (Lapp/cash/kfsm/Value;Lapp/cash/kfsm/State;)Ljava/lang/Object;
 }
 
 public abstract interface annotation class app/cash/kfsm/guice/annotations/TransitionDefinition : java/lang/annotation/Annotation {

--- a/lib-guice/src/test/kotlin/app/cash/kfsm/guice/test/KfsmGuiceIntegrationTest.kt
+++ b/lib-guice/src/test/kotlin/app/cash/kfsm/guice/test/KfsmGuiceIntegrationTest.kt
@@ -1,11 +1,13 @@
 package app.cash.kfsm.guice.test
 
+import app.cash.kfsm.NoPathToTargetState
 import app.cash.kfsm.guice.StateMachine
 import com.google.inject.Guice
 import com.google.inject.Key
 import com.google.inject.TypeLiteral
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -45,5 +47,17 @@ class KfsmGuiceIntegrationTest : StringSpec({
         val endValue = stateMachine.execute(middleValue, stateMachine.getTransition<MiddleToEnd>()).getOrThrow()
         val transitions = stateMachine.getAvailableTransitions(endValue.state)
         transitions shouldHaveSize 0
+    }
+
+    "transitionToState should succeed when transitioning to a directly reachable state" {
+        stateMachine.transitionToState(startValue, TestState.MIDDLE).getOrThrow().state shouldBe TestState.MIDDLE
+    }
+
+    "transitionToState should fail when transitioning to a non-directly reachable state" {
+      stateMachine.transitionToState(startValue, TestState.END).shouldBeFailure<NoPathToTargetState>()
+    }
+
+    "transitionToState should fail when transitioning to the same state" {
+      stateMachine.transitionToState(startValue, TestState.START).shouldBeFailure<NoPathToTargetState>()
     }
 }) 

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -1,3 +1,14 @@
+public final class app/cash/kfsm/InvalidStateForTransition : java/lang/Exception {
+	public fun <init> (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)V
+	public final fun component2 ()Lapp/cash/kfsm/Value;
+	public final fun copy (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)Lapp/cash/kfsm/InvalidStateForTransition;
+	public static synthetic fun copy$default (Lapp/cash/kfsm/InvalidStateForTransition;Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;ILjava/lang/Object;)Lapp/cash/kfsm/InvalidStateForTransition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Lapp/cash/kfsm/Value;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class app/cash/kfsm/InvalidStateMachine : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -9,15 +20,10 @@ public final class app/cash/kfsm/InvalidStateMachine : java/lang/Exception {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class app/cash/kfsm/InvalidStateTransition : java/lang/Exception {
-	public fun <init> (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)V
-	public final fun component2 ()Lapp/cash/kfsm/Value;
-	public final fun copy (Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;)Lapp/cash/kfsm/InvalidStateTransition;
-	public static synthetic fun copy$default (Lapp/cash/kfsm/InvalidStateTransition;Lapp/cash/kfsm/Transition;Lapp/cash/kfsm/Value;ILjava/lang/Object;)Lapp/cash/kfsm/InvalidStateTransition;
-	public fun equals (Ljava/lang/Object;)Z
+public final class app/cash/kfsm/NoPathToTargetState : java/lang/Exception {
+	public fun <init> (Lapp/cash/kfsm/Value;Lapp/cash/kfsm/State;)V
+	public final fun getTargetState ()Lapp/cash/kfsm/State;
 	public final fun getValue ()Lapp/cash/kfsm/Value;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public class app/cash/kfsm/State {

--- a/lib/src/main/kotlin/app/cash/kfsm/InvalidStateForTransition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/InvalidStateForTransition.kt
@@ -1,6 +1,6 @@
 package app.cash.kfsm
 
-data class InvalidStateTransition(private val transition: Transition<*, *, *>, val value: Value<*, *, *>) : Exception(
+data class InvalidStateForTransition(private val transition: Transition<*, *, *>, val value: Value<*, *, *>) : Exception(
   "Value cannot transition ${
     transition.from.set.toList().sortedBy { it.toString() }.joinToString(", ", prefix = "{", postfix = "}")
   } to ${transition.to}, because it is currently ${value.state}. [id=${value.id}]"

--- a/lib/src/main/kotlin/app/cash/kfsm/NoPathToTargetState.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/NoPathToTargetState.kt
@@ -1,0 +1,5 @@
+package app.cash.kfsm
+
+class NoPathToTargetState(val value: Value<*, *, *>, val targetState: State<*>) : Exception(
+  "No transition path exists from ${value.state} to $targetState for $value"
+)

--- a/lib/src/main/kotlin/app/cash/kfsm/Transitioner.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transitioner.kt
@@ -26,7 +26,7 @@ abstract class Transitioner<ID, T : Transition<ID, V, S>, V : Value<ID, V, S>, S
     // Self-cycled transitions will be effected by the first case.
     // If we still see a transition to self then this is a no-op.
     transition.to == value.state -> ignoreAlreadyCompletedTransition(value, transition)
-    else -> Result.failure(InvalidStateTransition(transition, value))
+    else -> Result.failure(InvalidStateForTransition(transition, value))
   }
 
   private fun doTheTransition(

--- a/lib/src/main/kotlin/app/cash/kfsm/TransitionerAsync.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/TransitionerAsync.kt
@@ -16,7 +16,7 @@ abstract class TransitionerAsync<ID, T : Transition<ID, V, S>, V : Value<ID, V, 
     // Self-cycled transitions will be effected by the first case.
     // If we still see a transition to self then this is a no-op.
     transition.to == value.state -> ignoreAlreadyCompletedTransition(value, transition)
-    else -> Result.failure(InvalidStateTransition(transition, value))
+    else -> Result.failure(InvalidStateForTransition(transition, value))
   }
 
   private suspend fun doTheTransition(

--- a/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/InvalidStateTransitionTest.kt
@@ -1,22 +1,21 @@
 package app.cash.kfsm
 
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 
 class InvalidStateTransitionTest : StringSpec({
   "with single from-state has correct message" {
-    InvalidStateTransition(LetterTransition(A, B), Letter(E, id = "my_letter")).message shouldBe
+    InvalidStateForTransition(LetterTransition(A, B), Letter(E, id = "my_letter")).message shouldBe
       "Value cannot transition {A} to B, because it is currently E. [id=my_letter]"
   }
 
   "with many from-states has correct message" {
-    InvalidStateTransition(LetterTransition(States(C, B), D), Letter(E, "my_letter")).message shouldBe
+    InvalidStateForTransition(LetterTransition(States(C, B), D), Letter(E, "my_letter")).message shouldBe
       "Value cannot transition {B, C} to D, because it is currently E. [id=my_letter]"
   }
 
   "exposes transition and state" {
-    val error = InvalidStateTransition(LetterTransition(A, B), Letter(E, "my_letter"))
+    val error = InvalidStateForTransition(LetterTransition(A, B), Letter(E, "my_letter"))
 
     error.getState<Char>() shouldBe E
   }


### PR DESCRIPTION
This PR introduces a new convenience function to the StateMachine API and renames an exception type for better clarity.

### New Feature
- Added `transitionToState` function to `StateMachine` that allows transitioning to a specific state if it's immediately reachable
- This provides a simpler API for cases where the caller knows the target state and doesn't need to specify a particular transition
- The function will only succeed if the target state is directly reachable from the current state

### Breaking Change
- Renamed `InvalidStateTransition` to `InvalidStateForTransition` to better reflect its purpose
- This is a breaking change that requires updating any code that catches or references this exception type

### Testing
- Added comprehensive tests for the new `transitionToState` function
- Tests cover successful transitions, invalid transitions, and transitions to the same state