### PR TITLE
Adds shortestPathTo method on State

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -52,6 +52,7 @@ public class app/cash/kfsm/State {
 	public fun canEventuallyTransitionTo (Lapp/cash/kfsm/State;)Z
 	public final fun getReachableStates ()Ljava/util/Set;
 	public final fun getSubsequentStates ()Ljava/util/Set;
+	public final fun shortestPathTo (Lapp/cash/kfsm/State;)Ljava/util/List;
 	public final fun validate-IoAF18A (Lapp/cash/kfsm/Value;)Ljava/lang/Object;
 }
 

--- a/lib/src/test/kotlin/app/cash/kfsm/StateTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/StateTest.kt
@@ -60,4 +60,9 @@ class StateTest : StringSpec({
     E.next(2) shouldBe emptyList()
   }
 
+  "returns shortest path" {
+    Red.shortestPathTo(Green) shouldBe listOf(Red, Yellow, Green)
+    Red.shortestPathTo(Yellow) shouldBe listOf(Red, Yellow)
+    Green.shortestPathTo(Red) shouldBe listOf(Green, Yellow, Red)
+  }
 })

--- a/lib/src/test/kotlin/app/cash/kfsm/TrafficLight.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/TrafficLight.kt
@@ -1,0 +1,18 @@
+package app.cash.kfsm
+
+/**
+ * A simple state machine modeling a traffic light.
+ */
+data class TrafficLight(override val state: Colour, override val id: String) : Value<String, TrafficLight, Colour> {
+  override fun update(newState: Colour): TrafficLight = copy(state = newState)
+}
+
+sealed class Colour(to: () -> Set<Colour>) : State<String, TrafficLight, Colour>(to) {
+  fun next(count: Int): List<Colour> =
+    if (count <= 0) emptyList()
+    else subsequentStates.filterNot { it == this }.firstOrNull()?.let { listOf(it) + it.next(count - 1) } ?: emptyList()
+}
+
+data object Red : Colour(to = { setOf(Yellow) })
+data object Yellow : Colour(to = { setOf(Green, Red) })
+data object Green : Colour(to = { setOf(Yellow) })


### PR DESCRIPTION
This is a generally useful method for a state machine, and avoids library consumers from having to implement this themselves.

- Adds a mechanism to calculate the shortest path from one state to another, using Breadth First Search (BFS).
- Adds a TrafficLight state machine for testing, with an intentional loop: (Red -> Yellow -> Red)