### PR TITLE
Updates CODEOWNERS to use GitHub team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @synesso @cwmyers @aparkersquare @mmollaverdi @hugomd @rgrnwd @ametke @cjustice @jacksoncook
+* @block/bitcoin-network-os @mmollaverdi @cjustice @jacksoncook


### PR DESCRIPTION
Updates CODEOWNERS to use a GitHub team, instead of individual collaborators. 

This will make it easier to add/remove internal collaborators in the future, without having to update `CODEOWNERS`.