### PR TITLE
Add default do-nothing transitioner to FSM DSL

### DIFF
--- a/lib/src/main/kotlin/app/cash/kfsm/v011/MachineBuilder.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v011/MachineBuilder.kt
@@ -6,6 +6,12 @@ import app.cash.kfsm.Transitioner
 import app.cash.kfsm.Value
 
 /**
+ * Default do-nothing transitioner that can be used when no special transition behavior is needed.
+ */
+class DefaultTransitioner<ID, T : Transition<ID, V, S>, V : Value<ID, V, S>, S : State<ID, V, S>> :
+  Transitioner<ID, T, V, S>()
+
+/**
  * Builder class for creating state machines with type-safe transitions.
  *
  * @param ID The type of the identifier used in the state machine
@@ -96,12 +102,12 @@ class MachineBuilder<ID, V : Value<ID, V, S>, S : State<ID, V, S>> {
  * @param ID The type of the identifier used in the state machine
  * @param V The type of value being transformed
  * @param S The type of state in the state machine
- * @param transitioner The transitioner to use for state transitions
+ * @param transitioner The transitioner to use for state transitions. If not provided, a default do-nothing transitioner will be used.
  * @param block A builder block that defines the state machine's transitions
  * @return A new [StateMachine] instance
  */
 inline fun <reified ID, V : Value<ID, V, S>, S : State<ID, V, S>> fsm(
-  transitioner: Transitioner<ID, Transition<ID, V, S>, V, S>,
+  transitioner: Transitioner<ID, Transition<ID, V, S>, V, S> = DefaultTransitioner(),
   noinline block: MachineBuilder<ID, V, S>.() -> Unit
 ): Result<StateMachine<ID, V, S>> = runCatching { MachineBuilder<ID, V, S>().apply(block).build(transitioner) }
 

--- a/lib/src/main/kotlin/app/cash/kfsm/v011/StateMachine.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v011/StateMachine.kt
@@ -10,6 +10,14 @@ class StateMachine<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
   private val transitioner: Transitioner<ID, Transition<ID, V, S>, V, S>
 ) {
   /**
+   * Returns all available transitions from a given state.
+   *
+   * @param state The current state
+   * @return Set of all possible transitions from the given state
+   */
+  fun getAvailableTransitions(state: S): Set<Transition<ID, V, S>> =
+    transitionMap[state]?.values?.toSet() ?: emptySet()
+  /**
    * Transitions a value to the target state if a valid transition exists.
    *
    * @param value The current value to transition

--- a/lib/src/test/kotlin/app/cash/kfsm/v011/MachineBuilderTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/v011/MachineBuilderTest.kt
@@ -19,16 +19,14 @@ import kotlin.runCatching
 
 class MachineBuilderTest :
   StringSpec({
-    val transitioner = object : Transitioner<String, Transition<String, Letter, Char>, Letter, Char>() {}
-
     "an empty machine" {
-      fsm(transitioner) {}
+      fsm<String, Letter, Char> {}
         .getOrThrow()
         .transitionMap shouldBe emptyMap()
     }
 
     "a self loop" {
-      fsm(transitioner) {
+      fsm<String, Letter, Char> {
         B becomes {
           B via { it }
         }
@@ -39,7 +37,7 @@ class MachineBuilderTest :
     }
 
     "mix of effect, transition and function values" {
-      fsm(transitioner) {
+      fsm<String, Letter, Char> {
         B becomes {
           B via { it }
           C via Effect { runCatching { it } }
@@ -53,7 +51,7 @@ class MachineBuilderTest :
     }
 
     "a full machine" {
-      fsm(transitioner) {
+      fsm<String, Letter, Char> {
         A.becomes {
           B.via { it }
         }
@@ -73,7 +71,7 @@ class MachineBuilderTest :
     }
 
     "disallows redeclaration of from state" {
-      fsm(transitioner) {
+      fsm<String, Letter, Char> {
         B.becomes {
           C.via { it }
         }
@@ -84,7 +82,7 @@ class MachineBuilderTest :
     }
 
     "disallows redeclaration of to state" {
-      fsm(transitioner) {
+      fsm<String, Letter, Char> {
         B.becomes {
           C.via { it }
           C.via { it }
@@ -93,7 +91,7 @@ class MachineBuilderTest :
     }
 
     "disallows transitions between states that do not permit them" {
-      fsm(transitioner) {
+      fsm<String, Letter, Char> {
         C.becomes {
           B.via { it }
         }

--- a/lib/src/test/kotlin/app/cash/kfsm/v011/StateMachineTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/v011/StateMachineTest.kt
@@ -18,6 +18,48 @@ class StateMachineTest :
   StringSpec({
     val transitioner = object : Transitioner<String, Transition<String, Letter, Char>, Letter, Char>() {}
 
+    "getAvailableTransitions returns all possible transitions from a state" {
+      // Given a machine with multiple transitions from state B
+      val machine = fsm(transitioner) {
+        A.becomes {
+          B.via { it.copy(id = "banana") }
+        }
+        B.becomes {
+          C.via { it.copy(id = "cinnamon") }
+          D.via { it.copy(id = "durian") }
+          B.via { it.copy(id = "berry") }
+        }
+        D.becomes {
+          E.via { it.copy(id = "eggplant") }
+        }
+      }.getOrThrow()
+
+      // When getting available transitions from state B
+      val transitions = machine.getAvailableTransitions(B)
+
+      // Then all transitions from B are returned
+      transitions.size shouldBe 3
+      transitions.map { it.to }.toSet() shouldBe setOf(B, C, D)
+    }
+
+    "getAvailableTransitions returns empty set for state with no transitions" {
+      // Given a machine with no transitions from state E
+      val machine = fsm(transitioner) {
+        A.becomes {
+          B.via { it.copy(id = "banana") }
+        }
+        B.becomes {
+          C.via { it.copy(id = "cinnamon") }
+        }
+      }.getOrThrow()
+
+      // When getting available transitions from state E
+      val transitions = machine.getAvailableTransitions(E)
+
+      // Then an empty set is returned
+      transitions shouldBe emptySet()
+    }
+
     "valid transition succeeds" {
       // Given a machine that allows A -> B
       val machine =


### PR DESCRIPTION
This PR adds a default do-nothing transitioner to the MachineBuilder FSM DSL, which simplifies the API for basic use cases.

Changes:
- Added a DefaultTransitioner class that extends Transitioner with no additional behavior
- Made DefaultTransitioner public since it's used in the public API
- Updated the fsm function to use DefaultTransitioner as the default value for its transitioner parameter
- Added appropriate documentation

Example usage:


The default transitioner will be used when no custom transitioner is needed, while still allowing custom transitioners when required.