### PR TITLE
Add mermaidStateDiagramMarkdown method to v011 StateMachine

### DIFF
--- a/lib/src/main/kotlin/app/cash/kfsm/v011/StateMachine.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/v011/StateMachine.kt
@@ -17,6 +17,7 @@ class StateMachine<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
    */
   fun getAvailableTransitions(state: S): Set<Transition<ID, V, S>> =
     transitionMap[state]?.values?.toSet() ?: emptySet()
+
   /**
    * Transitions a value to the target state if a valid transition exists.
    *
@@ -31,4 +32,34 @@ class StateMachine<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
     transitionMap[value.state]?.get(targetState)?.let { transition ->
       transitioner.transition(value, transition)
     } ?: Result.failure(IllegalStateException("No transition defined from ${value.state} to $targetState"))
+
+  /**
+   * Generates a Mermaid markdown state diagram representation of this state machine.
+   *
+   * The diagram shows all states and their possible transitions, making it easy to
+   * visualize and document the state machine's structure.
+   *
+   * Example output:
+   * ```mermaid
+   * stateDiagram-v2
+   *     [*] --> InitialState
+   *     InitialState --> NextState
+   *     NextState --> FinalState
+   * ```
+   *
+   * @param initialState The initial state to mark as the entry point
+   * @return A string containing the Mermaid markdown diagram
+   */
+  fun mermaidStateDiagramMarkdown(initialState: S): String {
+    val transitions = transitionMap.flatMap { (fromState, targets) ->
+      targets.keys.map { toState ->
+        "${fromState::class.simpleName} --> ${toState::class.simpleName}"
+      }
+    }.distinct().sorted()
+
+    return listOf(
+      "stateDiagram-v2",
+      "[*] --> ${initialState::class.simpleName}"
+    ).plus(transitions).joinToString("\n    ")
+  }
 }

--- a/lib/src/test/kotlin/app/cash/kfsm/v011/StateMachineTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/v011/StateMachineTest.kt
@@ -18,6 +18,37 @@ class StateMachineTest :
   StringSpec({
     val transitioner = object : Transitioner<String, Transition<String, Letter, Char>, Letter, Char>() {}
 
+    "mermaidStateDiagramMarkdown generates correct diagram" {
+      // Given a machine with multiple transitions
+      val machine = fsm(transitioner) {
+        A.becomes {
+          B.via { it.copy(id = "banana") }
+        }
+        B.becomes {
+          C.via { it.copy(id = "cinnamon") }
+          D.via { it.copy(id = "durian") }
+          B.via { it.copy(id = "berry") }
+        }
+        D.becomes {
+          E.via { it.copy(id = "eggplant") }
+        }
+      }.getOrThrow()
+
+      // When generating a diagram starting from A
+      val diagram = machine.mermaidStateDiagramMarkdown(A)
+
+      // Then the diagram contains all expected elements
+      diagram shouldBe """
+        |stateDiagram-v2
+        |    [*] --> A
+        |    A --> B
+        |    B --> B
+        |    B --> C
+        |    B --> D
+        |    D --> E
+      """.trimMargin()
+    }
+
     "getAvailableTransitions returns all possible transitions from a state" {
       // Given a machine with multiple transitions from state B
       val machine = fsm(transitioner) {


### PR DESCRIPTION
This PR adds a method to generate Mermaid state diagrams for v011 state machines, similar to the mermaid method in app.cash.kfsm.StateMachine.

Key changes:
- Added mermaidStateDiagramMarkdown method to v011.StateMachine
- Method works with v011 transition map and is an instance method
- Takes an initial state parameter to mark entry point
- Added comprehensive test case covering various transition types
- Test verifies correct Mermaid diagram generation

Example usage:
```kotlin
val machine = StateMachine(transitionMap, transitioner)
val diagram = machine.mermaidStateDiagramMarkdown(initialState)
```

Example output:
```mermaid
stateDiagram-v2
    [*] --> InitialState
    InitialState --> NextState
    NextState --> FinalState
```