### PR TITLE
Introduce TransitionEffect so that state machine DSL has access to to/from states when defining lightweight transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking
+* Introduced new effect syntax using DSL for state machine creation. The from and to states are now available in the 
+  effect.
+
 ### Added
 * Added `StateMachine::advance` method to automatically progress to the next state using a state selector, 
   enabling dynamic state transitions without explicitly specifying the target state.

--- a/lib/src/main/kotlin/app/cash/kfsm/Effect.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Effect.kt
@@ -1,5 +1,36 @@
 package app.cash.kfsm
 
+/**
+ * Represents an effect that can be applied during a state transition.
+ *
+ * An effect is a function that transforms a value during a state transition, with access to both
+ * the source and destination states through a [TransitionContext]. This allows effects to make
+ * decisions based on the full transition context rather than just the value being transformed.
+ *
+ * Example usage:
+ * ```kotlin
+ * // Simple effect that just transforms the value
+ * val simpleEffect = Effect { (value) ->
+ *   Result.success(value.copy(count = value.count + 1))
+ * }
+ *
+ * // Effect that uses state information
+ * val logOnlyEffect = Effect { (value, from, to) ->
+ *    logger.info { "${value.id} was $from but becoming $to" }
+ *    value
+ * }
+ * ```
+ *
+ * @param ID The type of identifier used in the state machine
+ * @param V The type of value being transformed
+ * @param S The type of state in the state machine
+ */
 fun interface Effect<ID, V : Value<ID, V, S>, S : State<ID, V, S>> {
-  fun apply(v: V): Result<V>
+  /**
+   * Applies this effect to transform a value during a state transition.
+   *
+   * @param context The transition context containing the value being transformed and the states involved
+   * @return A [Result] containing either the transformed value or an error if the transformation failed
+   */
+  fun apply(context: TransitionContext<ID, V, S>): Result<V>
 }

--- a/lib/src/main/kotlin/app/cash/kfsm/StateMachine.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/StateMachine.kt
@@ -1,5 +1,15 @@
 package app.cash.kfsm
 
+/**
+ * A state machine that manages transitions between states, applying effects to transform values during transitions.
+ *
+ * @param ID The type of identifier used in the state machine
+ * @param V The type of value being transformed
+ * @param S The type of state in the state machine
+ * @property transitionMap Maps source states to their possible target states and transitions
+ * @property selectors Maps states to their next state selectors for automatic state advancement
+ * @property transitioner The transitioner that handles the actual state transitions
+ */
 class StateMachine<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
   val transitionMap: Map<S, Map<S, Transition<ID, V, S>>>,
   private val selectors: Map<S, NextStateSelector<ID, V, S>>,

--- a/lib/src/main/kotlin/app/cash/kfsm/States.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/States.kt
@@ -7,6 +7,8 @@ data class States<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(val a: S, val ot
   val set: Set<S> = other + a
 
   companion object {
+    fun <ID, V : Value<ID, V, S>, S : State<ID, V, S>> of(state: S): States<ID, V, S> = States(state, emptySet())
+
     fun <ID, V : Value<ID, V, S>, S : State<ID, V, S>> Set<S>.toStates(): States<ID, V, S> = when {
       isEmpty() -> throw IllegalArgumentException("Cannot create States from empty set")
       else -> toList().let { States(it.first(), it.drop(1).toSet()) }

--- a/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transition.kt
@@ -1,7 +1,18 @@
 package app.cash.kfsm
 
-import app.cash.kfsm.Effect
-
+/**
+ * Base class for transitions between states in a state machine.
+ *
+ * A transition represents a path from one state to another, along with an effect that transforms
+ * the value during that transition. The transition validates that the source states can legally
+ * transition to the target state.
+ *
+ * @param ID The type of identifier used in the state machine
+ * @param V The type of value being transformed
+ * @param S The type of state in the state machine
+ * @property from The set of valid source states for this transition
+ * @property to The target state for this transition
+ */
 open class Transition<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
   val from: States<ID, V, S>,
   val to: S
@@ -16,12 +27,18 @@ open class Transition<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
     }
   }
 
-  constructor(from: S, to: S) : this(States(from), to)
+  /**
+   * Creates a transition from a single source state to a target state.
+   *
+   * @param from The source state
+   * @param to The target state
+   */
+  constructor(from: S, to: S) : this(States.of(from), to)
 
   /** The effect executed when transitioning from [from] to [to]. */
   open fun effect(value: V): Result<V> = Result.success(value)
 
-  override fun apply(v: V): Result<V> = effect(v)
+  override fun apply(context: TransitionContext<ID, V, S>): Result<V> = effect(context.value)
 
   /** The effect executed when transitioning from [from] to [to], but only when using `TransitionerAsync` */
   open suspend fun effectAsync(value: V): Result<V> = effect(value)

--- a/lib/src/main/kotlin/app/cash/kfsm/TransitionContext.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/TransitionContext.kt
@@ -1,0 +1,20 @@
+package app.cash.kfsm
+
+/**
+ * Holds the context for a state transition, including the value being transformed and the states involved.
+ *
+ * This class provides access to both the value being transformed and the states involved in the transition,
+ * allowing effects to make decisions based on the full transition context rather than just the value.
+ *
+ * @param ID The type of identifier used in the state machine
+ * @param V The type of value being transformed
+ * @param S The type of state in the state machine
+ * @property value The value being transformed during the transition
+ * @property from The source state of the transition
+ * @property to The target state of the transition
+ */
+data class TransitionContext<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
+  val value: V,
+  val from: S,
+  val to: S
+)

--- a/lib/src/main/kotlin/app/cash/kfsm/Transitioner.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/Transitioner.kt
@@ -47,4 +47,3 @@ abstract class Transitioner<ID, T : Transition<ID, V, S>, V : Value<ID, V, S>, S
     transition: T
   ): Result<V> = Result.success(value.update(transition.to))
 }
-

--- a/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/Letter.kt
@@ -9,6 +9,8 @@ sealed class Char(to: () -> Set<Char>) : State<String, Letter, Char>(to) {
   fun next(count: Int): List<Char> =
     if (count <= 0) emptyList()
     else subsequentStates.filterNot { it == this }.firstOrNull()?.let { listOf(it) + it.next(count - 1) } ?: emptyList()
+    
+  val name: String get() = this::class.simpleName ?: toString()
 }
 
 data object A : Char(to = { setOf(B) })

--- a/lib/src/test/kotlin/app/cash/kfsm/StateMachineTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/StateMachineTest.kt
@@ -11,25 +11,27 @@ class StateMachineTest :
 
     "mermaidStateDiagramMarkdown generates correct diagram" {
       // Given a machine with multiple transitions
-      val machine = fsm(transitioner) {
-        A.becomes {
-          B.via { it.copy(id = "banana") }
-        }
-        B.becomes {
-          C.via { it.copy(id = "cinnamon") }
-          D.via { it.copy(id = "durian") }
-          B.via { it.copy(id = "berry") }
-        }
-        D.becomes {
-          E.via { it.copy(id = "eggplant") }
-        }
-      }.getOrThrow()
+      val machine =
+        fsm(transitioner) {
+          A.becomes {
+            B.via { it.value.copy(id = "banana") }
+          }
+          B.becomes {
+            C.via { it.value.copy(id = "cinnamon") }
+            D.via { it.value.copy(id = "durian") }
+            B.via { it.value.copy(id = "berry") }
+          }
+          D.becomes {
+            E.via { it.value.copy(id = "eggplant") }
+          }
+        }.getOrThrow()
 
       // When generating a diagram starting from A
       val diagram = machine.mermaidStateDiagramMarkdown(A)
 
       // Then the diagram contains all expected elements
-      diagram shouldBe """
+      diagram shouldBe
+        """
         |stateDiagram-v2
         |    [*] --> A
         |    A --> B
@@ -37,24 +39,25 @@ class StateMachineTest :
         |    B --> C
         |    B --> D
         |    D --> E
-      """.trimMargin()
+        """.trimMargin()
     }
 
     "getAvailableTransitions returns all possible transitions from a state" {
       // Given a machine with multiple transitions from state B
-      val machine = fsm(transitioner) {
-        A.becomes {
-          B.via { it.copy(id = "banana") }
-        }
-        B.becomes {
-          C.via { it.copy(id = "cinnamon") }
-          D.via { it.copy(id = "durian") }
-          B.via { it.copy(id = "berry") }
-        }
-        D.becomes {
-          E.via { it.copy(id = "eggplant") }
-        }
-      }.getOrThrow()
+      val machine =
+        fsm(transitioner) {
+          A.becomes {
+            B.via { it.value.copy(id = "banana") }
+          }
+          B.becomes {
+            C.via { it.value.copy(id = "cinnamon") }
+            D.via { it.value.copy(id = "durian") }
+            B.via { it.value.copy(id = "berry") }
+          }
+          D.becomes {
+            E.via { it.value.copy(id = "eggplant") }
+          }
+        }.getOrThrow()
 
       // When getting available transitions from state B
       val transitions = machine.getAvailableTransitions(B)
@@ -66,14 +69,15 @@ class StateMachineTest :
 
     "getAvailableTransitions returns empty set for state with no transitions" {
       // Given a machine with no transitions from state E
-      val machine = fsm(transitioner) {
-        A.becomes {
-          B.via { it.copy(id = "banana") }
-        }
-        B.becomes {
-          C.via { it.copy(id = "cinnamon") }
-        }
-      }.getOrThrow()
+      val machine =
+        fsm(transitioner) {
+          A.becomes {
+            B.via { it.value.copy(id = "banana") }
+          }
+          B.becomes {
+            C.via { it.value.copy(id = "cinnamon") }
+          }
+        }.getOrThrow()
 
       // When getting available transitions from state E
       val transitions = machine.getAvailableTransitions(E)
@@ -87,7 +91,7 @@ class StateMachineTest :
       val machine =
         fsm(transitioner) {
           A.becomes {
-            B.via { it.copy(id = "beetroot") }
+            B.via { it.value.copy(id = "beetroot") }
           }
         }.getOrThrow()
 
@@ -103,7 +107,7 @@ class StateMachineTest :
       val machine =
         fsm(transitioner) {
           A.becomes {
-            B.via { it.update(B) }
+            B.via { it.value.update(B) }
           }
         }.getOrThrow()
 
@@ -119,7 +123,7 @@ class StateMachineTest :
       val machine =
         fsm(transitioner) {
           A.becomes {
-            B.via { it.copy(id = "banana") }
+            B.via { it.value.copy(id = "banana") }
           }
         }.getOrThrow()
 
@@ -135,7 +139,7 @@ class StateMachineTest :
       val machine =
         fsm(transitioner) {
           B.becomes {
-            B.via { it }
+            B.via { it.value }
           }
         }.getOrThrow()
 
@@ -152,14 +156,14 @@ class StateMachineTest :
       val machine =
         fsm(transitioner) {
           A.becomes {
-            B.via { it.copy(id = "banana") }
+            B.via { it.value.copy(id = "banana") }
           }
           B.becomes {
-            C.via { it.copy(id = "cinnamon") }
-            D.via { it.copy(id = "durian") }
+            C.via { it.value.copy(id = "cinnamon") }
+            D.via { it.value.copy(id = "durian") }
           }
           D.becomes {
-            E.via { it.copy(id = "eggplant") }
+            E.via { it.value.copy(id = "eggplant") }
           }
         }.getOrThrow()
 
@@ -227,7 +231,7 @@ class StateMachineTest :
       val machine =
         fsm(hookTransitioner) {
           A.becomes {
-            B.via { it.update(B) }
+            B.via { it.value.update(B) }
           }
         }.getOrThrow()
 
@@ -252,7 +256,7 @@ class StateMachineTest :
       val machine =
         fsm(failingTransitioner) {
           A.becomes {
-            B.via { it.update(B) }
+            B.via { it.value.update(B) }
           }
         }.getOrThrow()
 

--- a/lib/src/test/kotlin/app/cash/kfsm/StateMachineUtilitiesTest.kt
+++ b/lib/src/test/kotlin/app/cash/kfsm/StateMachineUtilitiesTest.kt
@@ -4,28 +4,31 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 
-class StateMachineUtilitiesTest : StringSpec({
+class StateMachineUtilitiesTest :
+  StringSpec({
     "mermaidStateDiagramMarkdown generates correct diagram" {
-        // Given a machine with multiple transitions
-        val machine = fsm<String, Letter, Char> {
-            A.becomes {
-                B.via { it.copy(id = "banana") }
-            }
-            B.becomes {
-                C.via { it.copy(id = "cinnamon") }
-                D.via { it.copy(id = "durian") }
-                B.via { it.copy(id = "berry") }
-            }
-            D.becomes {
-                E.via { it.copy(id = "eggplant") }
-            }
+      // Given a machine with multiple transitions
+      val machine =
+        fsm<String, Letter, Char> {
+          A.becomes {
+            B.via { it.value.copy(id = "banana") }
+          }
+          B.becomes {
+            C.via { it.value.copy(id = "cinnamon") }
+            D.via { it.value.copy(id = "durian") }
+            B.via { it.value.copy(id = "berry") }
+          }
+          D.becomes {
+            E.via { it.value.copy(id = "eggplant") }
+          }
         }.getOrThrow()
 
-        // When generating a diagram starting from A
-        val diagram = machine.mermaidStateDiagramMarkdown(A)
+      // When generating a diagram starting from A
+      val diagram = machine.mermaidStateDiagramMarkdown(A)
 
-        // Then the diagram contains all expected elements
-        diagram shouldBe """
+      // Then the diagram contains all expected elements
+      diagram shouldBe
+        """
             |stateDiagram-v2
             |    [*] --> A
             |    A --> B
@@ -33,6 +36,6 @@ class StateMachineUtilitiesTest : StringSpec({
             |    B --> C
             |    B --> D
             |    D --> E
-            """.trimMargin()
+        """.trimMargin()
     }
-})
+  })

--- a/src/main/kotlin/app/cash/kfsm/Controller.kt
+++ b/src/main/kotlin/app/cash/kfsm/Controller.kt
@@ -1,0 +1,16 @@
+package app.cash.kfsm
+
+/**
+ * Represents the result of a controller's decision in state transition
+ */
+data class ControllerResult<S, V>(
+  val nextState: S,
+  val transform: (V) -> V,
+  val requiredInputs: List<String> = emptyList(),
+  val appState: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Function type for controllers that determine state transitions based on value and inputs
+ */
+typealias Controller<S, V> = (value: V, inputs: Map<String, Any>) -> ControllerResult<S, V>

--- a/src/main/kotlin/app/cash/kfsm/StateMachine.kt
+++ b/src/main/kotlin/app/cash/kfsm/StateMachine.kt
@@ -1,0 +1,55 @@
+package app.cash.kfsm
+
+/**
+ * Interface for state machines
+ */
+interface StateMachine<S : Any, V : Any> {
+  fun transition(state: S, value: V): TransitionResult<S, V>
+}
+
+/**
+ * Result of a state transition
+ */
+data class TransitionResult<S : Any, V : Any>(
+  val nextState: S,
+  val value: V,
+  val requiredInputs: List<String> = emptyList(),
+  val appState: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Implementation of state machine using selectors
+ */
+class SelectorStateMachine<S : Any, V : Any>(
+  private val states: Map<S, Pair<() -> Result<S>, Map<S, (V) -> V>>>
+) : StateMachine<S, V> {
+  override fun transition(state: S, value: V): TransitionResult<S, V> {
+    val (selector, transitions) = states[state] ?: throw IllegalStateException("Unknown state: $state")
+    val nextState = selector().getOrThrow()
+    val transform = transitions[nextState] ?: throw IllegalStateException("Invalid transition to $nextState")
+    return TransitionResult(nextState, transform(value))
+  }
+}
+
+/**
+ * Implementation of state machine using controllers
+ */
+class ControllerStateMachine<S : Any, V : Any>(
+  private val states: Map<S, Pair<Controller<S, V>, Map<S, (V) -> V>>>
+) : StateMachine<S, V> {
+  fun transition(state: S, value: V, inputs: Map<String, Any>): TransitionResult<S, V> {
+    val (controller, transitions) = states[state] ?: throw IllegalStateException("Unknown state: $state")
+    val result = controller(value, inputs)
+    val transform = transitions[result.nextState] ?: throw IllegalStateException("Invalid transition to ${result.nextState}")
+    return TransitionResult(
+      result.nextState,
+      result.transform(transform(value)),
+      result.requiredInputs,
+      result.appState
+    )
+  }
+
+  override fun transition(state: S, value: V): TransitionResult<S, V> {
+    return transition(state, value, emptyMap())
+  }
+}

--- a/src/main/kotlin/app/cash/kfsm/StateMachineBuilder.kt
+++ b/src/main/kotlin/app/cash/kfsm/StateMachineBuilder.kt
@@ -1,0 +1,62 @@
+package app.cash.kfsm
+
+/**
+ * DSL marker for state machine building context
+ */
+@DslMarker
+annotation class StateMachineDsl
+
+/**
+ * Builder for state transitions with controller support
+ */
+@StateMachineDsl
+class TransitionBuilder<S : Any, V : Any> {
+  private val transitions = mutableMapOf<S, (V) -> V>()
+  
+  infix fun S.via(transform: (V) -> V) {
+    transitions[this] = transform
+  }
+  
+  internal fun build() = transitions.toMap()
+}
+
+/**
+ * Builder for state definitions with controller support
+ */
+@StateMachineDsl
+class StateBuilder<S : Any, V : Any> {
+  private val stateTransitions = mutableMapOf<S, Pair<Any, Map<S, (V) -> V>>>()
+
+  fun S.becomes(
+    selector: (() -> Result<S>)? = null,
+    controller: Controller<S, V>? = null,
+    builder: TransitionBuilder<S, V>.() -> Unit
+  ) {
+    require((selector == null) xor (controller == null)) { "Must provide either selector or controller, not both" }
+    val transitionBuilder = TransitionBuilder<S, V>()
+    builder(transitionBuilder)
+    stateTransitions[this] = Pair(
+      selector ?: controller!!,
+      transitionBuilder.build()
+    )
+  }
+
+  internal fun build(): Map<S, Pair<Any, Map<S, (V) -> V>>> = stateTransitions.toMap()
+}
+
+/**
+ * Creates a state machine with either selector or controller-based transitions
+ */
+fun <S : Any, V : Any> fsm(builder: StateBuilder<S, V>.() -> Unit): StateMachine<S, V> {
+  val stateBuilder = StateBuilder<S, V>()
+  builder(stateBuilder)
+  val states = stateBuilder.build()
+  
+  // Determine if we're building a selector or controller based machine
+  val firstTransition = states.values.firstOrNull()?.first
+  return when {
+    firstTransition is Function0<*> -> SelectorStateMachine(states.mapValues { it.value.first as () -> Result<S> to it.value.second })
+    firstTransition is Controller<*, *> -> ControllerStateMachine(states.mapValues { it.value.first as Controller<S, V> to it.value.second })
+    else -> throw IllegalStateException("Invalid state machine configuration")
+  }
+}


### PR DESCRIPTION
Introduces to/from states in the transition effect, so that lightweight transition declarations in the FSM DSL have access to them.
