### PR TITLE
Change exception on failure to find an edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fix
+
+* Restored exception in cases of invalid transition attempts to be NoPathToTargetState
+
 ## [0.11.1]
 
 ### Added

--- a/lib/src/main/kotlin/app/cash/kfsm/StateMachine.kt
+++ b/lib/src/main/kotlin/app/cash/kfsm/StateMachine.kt
@@ -26,7 +26,7 @@ class StateMachine<ID, V : Value<ID, V, S>, S : State<ID, V, S>>(
   ): Result<V> =
     transitionMap[value.state]?.get(targetState)?.let { transition ->
       transitioner.transition(value, transition)
-    } ?: Result.failure(IllegalStateException("No transition defined from ${value.state} to $targetState"))
+    } ?: Result.failure(NoPathToTargetState(value, targetState))
 
   /**
    * Advances the state machine to the next state based on the current value.


### PR DESCRIPTION
In the new state machine type, match the exception type used in the prior (Guice based) state machine when an edge is attempted but doesn't exist.